### PR TITLE
The header in the middle of this file was needless

### DIFF
--- a/nj_municipal_codes.csv
+++ b/nj_municipal_codes.csv
@@ -396,7 +396,6 @@ code,municipality
 1422,Morris Twp
 1423,Morris Plains
 1424,Morristown Town
-,Code Municipality
 1425,Mountain Lakes
 1426,Mount Arlington
 1427,Mount Olive


### PR DESCRIPTION
It's gone now.